### PR TITLE
fix: print the result as json

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,5 @@
 import argparse
-from pprint import pprint
+import json
 
 from capfalcnlp.helpers import read_file
 from capfalcnlp.processing import spacy_process
@@ -12,4 +12,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
     text = read_file(args.input_file)
     detections = get_detections(text)
-    pprint(detections)
+    print(json.dumps(detections))


### PR DESCRIPTION
Detections are sent as plain text but unapei requires it to be returned as json.